### PR TITLE
Prevent double taps from zooming in on iOS Safari

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1,3 +1,5 @@
+body { touch-action: manipulation; }
+
 .Header {
   max-width: 600px;
 }


### PR DESCRIPTION
An excited player tapping too fast will cause iOS Safari to interpret it as `Zoom In`. This PR prevents that from happening.

Video shows before and after:

https://user-images.githubusercontent.com/473/149609923-37a68655-467d-422a-98a9-5d0b513674bd.mov

