### PR TITLE
Set a unique url for each word

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -16,11 +16,13 @@
             "elm/random": "1.0.0",
             "elm/svg": "1.0.1",
             "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
             "elm-community/list-extra": "8.5.2",
             "elm-community/string-extra": "4.0.1",
             "elm-explorations/markdown": "1.0.0",
             "lukewestby/elm-string-interpolate": "1.0.4",
             "pablen/toasty": "1.2.0",
+            "pdamoc/elm-hashids": "1.0.4",
             "terezka/elm-charts": "3.0.0"
         },
         "indirect": {
@@ -30,7 +32,6 @@
             "elm/file": "1.0.5",
             "elm/parser": "1.1.0",
             "elm/regex": "1.0.0",
-            "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2",
             "justinmimbs/date": "3.2.1",
             "justinmimbs/time-extra": "1.1.0",

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -150,7 +150,7 @@ init flags url key =
                         wordRef =
                             maybeWordRef |> Maybe.withDefault { lang = defaultLang, size = defaultSize, id = "" }
                     in
-                    ( initialModel (Store.default (I18n.parseLang wordRef.lang)) key wordRef Game.Idle, Cmd.none )
+                    ( initialModel { store | lang = I18n.parseLang wordRef.lang } key wordRef Game.Idle, Cmd.none )
 
                 Err error ->
                     let


### PR DESCRIPTION
This updates the url with a unique hash so we can share words with links like this : https://mmai.github.io/wordlem/#fr-FR/6/AMd

I think this is an interesting feature, but I had to make changes in a lot of places, and I am still discovering elm, so I won't be disapointed if you don't merge this pull request :)